### PR TITLE
Anonymize channel names

### DIFF
--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -973,7 +973,7 @@ class Modmail(commands.Cog):
             embed = discord.Embed(
                 color=self.bot.error_color, description="Cannot start a thread with a bot."
             )
-            return await ctx.send(embed=embed, delete_afer=3)
+            return await ctx.send(embed=embed, delete_after=3)
 
         exists = await self.bot.threads.find(recipient=user)
         if exists:

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -66,7 +66,8 @@ class Modmail(commands.Cog):
         for level in PermissionLevel:
             if level <= PermissionLevel.REGULAR:
                 continue
-            permissions = self.bot.config["level_permissions"].get(level.name, [])
+            permissions = self.bot.config["level_permissions"].get(
+                level.name, [])
             for perm in permissions:
                 perm = int(perm)
                 if perm == -1:
@@ -76,8 +77,10 @@ class Modmail(commands.Cog):
                     if key is None:
                         key = self.bot.modmail_guild.get_role(perm)
                 if key is not None:
-                    logger.info("Granting %s access to Modmail category.", key.name)
-                    overwrites[key] = discord.PermissionOverwrite(read_messages=True)
+                    logger.info(
+                        "Granting %s access to Modmail category.", key.name)
+                    overwrites[key] = discord.PermissionOverwrite(
+                        read_messages=True)
 
         category = await self.bot.modmail_guild.create_category(
             name="Modmail", overwrites=overwrites
@@ -104,7 +107,8 @@ class Modmail(commands.Cog):
             "feeling extra generous, buy us coffee on [Patreon](https://patreon.com/kyber) :heart:!",
         )
 
-        embed.set_footer(text=f'Type "{self.bot.prefix}help" for a complete list of commands.')
+        embed.set_footer(
+            text=f'Type "{self.bot.prefix}help" for a complete list of commands.')
         await log_channel.send(embed=embed)
 
         self.bot.config["main_category_id"] = category.id
@@ -152,7 +156,8 @@ class Modmail(commands.Cog):
         if name is not None:
             val = self.bot.snippets.get(name)
             if val is None:
-                embed = create_not_found_embed(name, self.bot.snippets.keys(), "Snippet")
+                embed = create_not_found_embed(
+                    name, self.bot.snippets.keys(), "Snippet")
             else:
                 embed = discord.Embed(
                     title=f'Snippet - "{name}":', description=val, color=self.bot.main_color
@@ -163,7 +168,8 @@ class Modmail(commands.Cog):
             embed = discord.Embed(
                 color=self.bot.error_color, description="You dont have any snippets at the moment."
             )
-            embed.set_footer(text=f'Check "{self.bot.prefix}help snippet add" to add a snippet.')
+            embed.set_footer(
+                text=f'Check "{self.bot.prefix}help snippet add" to add a snippet.')
             embed.set_author(name="Snippets", icon_url=ctx.guild.icon_url)
             return await ctx.send(embed=embed)
 
@@ -171,7 +177,8 @@ class Modmail(commands.Cog):
 
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.snippets)),) * 15)):
             description = format_description(i, names)
-            embed = discord.Embed(color=self.bot.main_color, description=description)
+            embed = discord.Embed(
+                color=self.bot.main_color, description=description)
             embed.set_author(name="Snippets", icon_url=ctx.guild.icon_url)
             embeds.append(embed)
 
@@ -186,7 +193,8 @@ class Modmail(commands.Cog):
         """
         val = self.bot.snippets.get(name)
         if val is None:
-            embed = create_not_found_embed(name, self.bot.snippets.keys(), "Snippet")
+            embed = create_not_found_embed(
+                name, self.bot.snippets.keys(), "Snippet")
         else:
             val = truncate(escape_code_block(val), 2048 - 7)
             embed = discord.Embed(
@@ -260,7 +268,8 @@ class Modmail(commands.Cog):
             self.bot.snippets.pop(name)
             await self.bot.config.update()
         else:
-            embed = create_not_found_embed(name, self.bot.snippets.keys(), "Snippet")
+            embed = create_not_found_embed(
+                name, self.bot.snippets.keys(), "Snippet")
         await ctx.send(embed=embed)
 
     @snippet.command(name="edit")
@@ -283,7 +292,8 @@ class Modmail(commands.Cog):
                 description=f'`{name}` will now send "{value}".',
             )
         else:
-            embed = create_not_found_embed(name, self.bot.snippets.keys(), "Snippet")
+            embed = create_not_found_embed(
+                name, self.bot.snippets.keys(), "Snippet")
         await ctx.send(embed=embed)
 
     @commands.command(usage="<category> [options]")
@@ -359,7 +369,8 @@ class Modmail(commands.Cog):
         if after.arg and not silent:
             embed.add_field(name="Message", value=after.arg)
 
-        embed.set_footer(text="Closing will be cancelled if a thread message is sent.")
+        embed.set_footer(
+            text="Closing will be cancelled if a thread message is sent.")
         embed.timestamp = after.dt
 
         await ctx.send(embed=embed)
@@ -444,7 +455,8 @@ class Modmail(commands.Cog):
         """
         mention = self.parse_user_or_role(ctx, user_or_role)
         if mention is None:
-            raise commands.BadArgument(f"{user_or_role} is not a valid user or role.")
+            raise commands.BadArgument(
+                f"{user_or_role} is not a valid user or role.")
 
         thread = ctx.thread
 
@@ -521,7 +533,8 @@ class Modmail(commands.Cog):
         """
         mention = self.parse_user_or_role(ctx, user_or_role)
         if mention is None:
-            raise commands.BadArgument(f"{user_or_role} is not a valid user or role.")
+            raise commands.BadArgument(
+                f"{user_or_role} is not a valid user or role.")
 
         thread = ctx.thread
 
@@ -624,10 +637,13 @@ class Modmail(commands.Cog):
             username = entry["recipient"]["name"] + "#"
             username += entry["recipient"]["discriminator"]
 
-            embed = discord.Embed(color=self.bot.main_color, timestamp=created_at)
-            embed.set_author(name=f"{title} - {username}", icon_url=avatar_url, url=log_url)
+            embed = discord.Embed(
+                color=self.bot.main_color, timestamp=created_at)
+            embed.set_author(name=f"{title} - {username}",
+                             icon_url=avatar_url, url=log_url)
             embed.url = log_url
-            embed.add_field(name="Created", value=duration(created_at, now=datetime.utcnow()))
+            embed.add_field(name="Created", value=duration(
+                created_at, now=datetime.utcnow()))
             closer = entry.get("closer")
             if closer is None:
                 closer_msg = "Unknown"
@@ -636,9 +652,11 @@ class Modmail(commands.Cog):
             embed.add_field(name="Closed By", value=closer_msg)
 
             if entry["recipient"]["id"] != entry["creator"]["id"]:
-                embed.add_field(name="Created by", value=f"<@{entry['creator']['id']}>")
+                embed.add_field(name="Created by",
+                                value=f"<@{entry['creator']['id']}>")
 
-            embed.add_field(name="Preview", value=format_preview(entry["messages"]), inline=False)
+            embed.add_field(name="Preview", value=format_preview(
+                entry["messages"]), inline=False)
 
             if closer is not None:
                 # BUG: Currently, logviewer can't display logs without a closer.
@@ -647,7 +665,8 @@ class Modmail(commands.Cog):
                 logger.debug("Invalid log entry: no closer.")
                 embed.add_field(name="Log Key", value=f"`{entry['key']}`")
 
-            embed.set_footer(text="Recipient ID: " + str(entry["recipient"]["id"]))
+            embed.set_footer(text="Recipient ID: " +
+                             str(entry["recipient"]["id"]))
             embeds.append(embed)
         return embeds
 
@@ -678,7 +697,8 @@ class Modmail(commands.Cog):
         if not user:
             thread = ctx.thread
             if not thread:
-                raise commands.MissingRequiredArgument(SimpleNamespace(name="member"))
+                raise commands.MissingRequiredArgument(
+                    SimpleNamespace(name="member"))
             user = thread.recipient
 
         default_avatar = "https://cdn.discordapp.com/embed/avatars/0.png"
@@ -712,7 +732,8 @@ class Modmail(commands.Cog):
         user = user if user is not None else ctx.author
 
         entries = await self.bot.api.search_closed_by(user.id)
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon_url)
+        embeds = self.format_log_embeds(
+            entries, avatar_url=self.bot.guild.icon_url)
 
         if not embeds:
             embed = discord.Embed(
@@ -762,7 +783,8 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.get_responded_logs(user.id)
 
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon_url)
+        embeds = self.format_log_embeds(
+            entries, avatar_url=self.bot.guild.icon_url)
 
         if not embeds:
             embed = discord.Embed(
@@ -787,7 +809,8 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.search_by_text(query, limit)
 
-        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon_url)
+        embeds = self.format_log_embeds(
+            entries, avatar_url=self.bot.guild.icon_url)
 
         if not embeds:
             embed = discord.Embed(
@@ -987,7 +1010,8 @@ class Modmail(commands.Cog):
         else:
             thread = await self.bot.threads.create(user, creator=ctx.author, category=category)
             if self.bot.config["dm_disabled"] in (DMDisabled.NEW_THREADS, DMDisabled.ALL_THREADS):
-                logger.info("Contacting user %s when Modmail DM is disabled.", user)
+                logger.info(
+                    "Contacting user %s when Modmail DM is disabled.", user)
 
             if not silent and not self.bot.config.get("thread_contact_silently"):
                 if ctx.author.id == user.id:
@@ -1023,7 +1047,8 @@ class Modmail(commands.Cog):
     async def blocked(self, ctx):
         """Retrieve a list of blocked users."""
 
-        embeds = [discord.Embed(title="Blocked Users", color=self.bot.main_color, description="")]
+        embeds = [discord.Embed(title="Blocked Users",
+                                color=self.bot.main_color, description="")]
 
         roles = []
         users = []
@@ -1062,7 +1087,8 @@ class Modmail(commands.Cog):
             embeds[0].description = "Currently there are no blocked users."
 
         embeds.append(
-            discord.Embed(title="Blocked Roles", color=self.bot.main_color, description="")
+            discord.Embed(title="Blocked Roles",
+                          color=self.bot.main_color, description="")
         )
 
         if roles:
@@ -1167,7 +1193,8 @@ class Modmail(commands.Cog):
             if thread:
                 user_or_role = thread.recipient
             elif after is None:
-                raise commands.MissingRequiredArgument(SimpleNamespace(name="user"))
+                raise commands.MissingRequiredArgument(
+                    SimpleNamespace(name="user"))
             else:
                 raise commands.BadArgument(f'User "{after.arg}" not found.')
 
@@ -1188,7 +1215,8 @@ class Modmail(commands.Cog):
 
         if after is not None:
             if "%" in reason:
-                raise commands.BadArgument('The reason contains illegal character "%".')
+                raise commands.BadArgument(
+                    'The reason contains illegal character "%".')
             if after.arg:
                 reason += f" for `{after.arg}`"
             if after.dt > after.now:
@@ -1244,7 +1272,8 @@ class Modmail(commands.Cog):
             if thread:
                 user_or_role = thread.recipient
             else:
-                raise commands.MissingRequiredArgument(SimpleNamespace(name="user"))
+                raise commands.MissingRequiredArgument(
+                    SimpleNamespace(name="user"))
 
         mention = getattr(user_or_role, "mention", f"`{user_or_role.id}`")
         name = getattr(user_or_role, "name", f"`{user_or_role.id}`")
@@ -1340,7 +1369,8 @@ class Modmail(commands.Cog):
 
         # Search cache for channel
         user_id, thread = next(
-            ((k, v) for k, v in self.bot.threads.cache.items() if v.channel == ctx.channel),
+            ((k, v) for k, v in self.bot.threads.cache.items()
+             if v.channel == ctx.channel),
             (-1, None),
         )
         if thread is not None:
@@ -1368,9 +1398,7 @@ class Modmail(commands.Cog):
                             self.bot.threads, recipient, ctx.channel
                         )
                     thread.ready = True
-                    logger.info(
-                        "Created new thread for current channel."
-                    )
+                    logger.info("Created new thread for current channel.")
                     return await self.bot.add_reaction(ctx.message, sent_emoji)
 
         else:

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -66,8 +66,7 @@ class Modmail(commands.Cog):
         for level in PermissionLevel:
             if level <= PermissionLevel.REGULAR:
                 continue
-            permissions = self.bot.config["level_permissions"].get(
-                level.name, [])
+            permissions = self.bot.config["level_permissions"].get(level.name, [])
             for perm in permissions:
                 perm = int(perm)
                 if perm == -1:
@@ -77,10 +76,8 @@ class Modmail(commands.Cog):
                     if key is None:
                         key = self.bot.modmail_guild.get_role(perm)
                 if key is not None:
-                    logger.info(
-                        "Granting %s access to Modmail category.", key.name)
-                    overwrites[key] = discord.PermissionOverwrite(
-                        read_messages=True)
+                    logger.info("Granting %s access to Modmail category.", key.name)
+                    overwrites[key] = discord.PermissionOverwrite(read_messages=True)
 
         category = await self.bot.modmail_guild.create_category(
             name="Modmail", overwrites=overwrites
@@ -107,8 +104,7 @@ class Modmail(commands.Cog):
             "feeling extra generous, buy us coffee on [Patreon](https://patreon.com/kyber) :heart:!",
         )
 
-        embed.set_footer(
-            text=f'Type "{self.bot.prefix}help" for a complete list of commands.')
+        embed.set_footer(text=f'Type "{self.bot.prefix}help" for a complete list of commands.')
         await log_channel.send(embed=embed)
 
         self.bot.config["main_category_id"] = category.id
@@ -156,8 +152,7 @@ class Modmail(commands.Cog):
         if name is not None:
             val = self.bot.snippets.get(name)
             if val is None:
-                embed = create_not_found_embed(
-                    name, self.bot.snippets.keys(), "Snippet")
+                embed = create_not_found_embed(name, self.bot.snippets.keys(), "Snippet")
             else:
                 embed = discord.Embed(
                     title=f'Snippet - "{name}":', description=val, color=self.bot.main_color
@@ -168,8 +163,7 @@ class Modmail(commands.Cog):
             embed = discord.Embed(
                 color=self.bot.error_color, description="You dont have any snippets at the moment."
             )
-            embed.set_footer(
-                text=f'Check "{self.bot.prefix}help snippet add" to add a snippet.')
+            embed.set_footer(text=f'Check "{self.bot.prefix}help snippet add" to add a snippet.')
             embed.set_author(name="Snippets", icon_url=ctx.guild.icon_url)
             return await ctx.send(embed=embed)
 
@@ -177,8 +171,7 @@ class Modmail(commands.Cog):
 
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.snippets)),) * 15)):
             description = format_description(i, names)
-            embed = discord.Embed(
-                color=self.bot.main_color, description=description)
+            embed = discord.Embed(color=self.bot.main_color, description=description)
             embed.set_author(name="Snippets", icon_url=ctx.guild.icon_url)
             embeds.append(embed)
 
@@ -193,8 +186,7 @@ class Modmail(commands.Cog):
         """
         val = self.bot.snippets.get(name)
         if val is None:
-            embed = create_not_found_embed(
-                name, self.bot.snippets.keys(), "Snippet")
+            embed = create_not_found_embed(name, self.bot.snippets.keys(), "Snippet")
         else:
             val = truncate(escape_code_block(val), 2048 - 7)
             embed = discord.Embed(
@@ -268,8 +260,7 @@ class Modmail(commands.Cog):
             self.bot.snippets.pop(name)
             await self.bot.config.update()
         else:
-            embed = create_not_found_embed(
-                name, self.bot.snippets.keys(), "Snippet")
+            embed = create_not_found_embed(name, self.bot.snippets.keys(), "Snippet")
         await ctx.send(embed=embed)
 
     @snippet.command(name="edit")
@@ -292,8 +283,7 @@ class Modmail(commands.Cog):
                 description=f'`{name}` will now send "{value}".',
             )
         else:
-            embed = create_not_found_embed(
-                name, self.bot.snippets.keys(), "Snippet")
+            embed = create_not_found_embed(name, self.bot.snippets.keys(), "Snippet")
         await ctx.send(embed=embed)
 
     @commands.command(usage="<category> [options]")
@@ -369,8 +359,7 @@ class Modmail(commands.Cog):
         if after.arg and not silent:
             embed.add_field(name="Message", value=after.arg)
 
-        embed.set_footer(
-            text="Closing will be cancelled if a thread message is sent.")
+        embed.set_footer(text="Closing will be cancelled if a thread message is sent.")
         embed.timestamp = after.dt
 
         await ctx.send(embed=embed)
@@ -455,8 +444,7 @@ class Modmail(commands.Cog):
         """
         mention = self.parse_user_or_role(ctx, user_or_role)
         if mention is None:
-            raise commands.BadArgument(
-                f"{user_or_role} is not a valid user or role.")
+            raise commands.BadArgument(f"{user_or_role} is not a valid user or role.")
 
         thread = ctx.thread
 
@@ -533,8 +521,7 @@ class Modmail(commands.Cog):
         """
         mention = self.parse_user_or_role(ctx, user_or_role)
         if mention is None:
-            raise commands.BadArgument(
-                f"{user_or_role} is not a valid user or role.")
+            raise commands.BadArgument(f"{user_or_role} is not a valid user or role.")
 
         thread = ctx.thread
 
@@ -637,13 +624,10 @@ class Modmail(commands.Cog):
             username = entry["recipient"]["name"] + "#"
             username += entry["recipient"]["discriminator"]
 
-            embed = discord.Embed(
-                color=self.bot.main_color, timestamp=created_at)
-            embed.set_author(name=f"{title} - {username}",
-                             icon_url=avatar_url, url=log_url)
+            embed = discord.Embed(color=self.bot.main_color, timestamp=created_at)
+            embed.set_author(name=f"{title} - {username}", icon_url=avatar_url, url=log_url)
             embed.url = log_url
-            embed.add_field(name="Created", value=duration(
-                created_at, now=datetime.utcnow()))
+            embed.add_field(name="Created", value=duration(created_at, now=datetime.utcnow()))
             closer = entry.get("closer")
             if closer is None:
                 closer_msg = "Unknown"
@@ -652,11 +636,9 @@ class Modmail(commands.Cog):
             embed.add_field(name="Closed By", value=closer_msg)
 
             if entry["recipient"]["id"] != entry["creator"]["id"]:
-                embed.add_field(name="Created by",
-                                value=f"<@{entry['creator']['id']}>")
+                embed.add_field(name="Created by", value=f"<@{entry['creator']['id']}>")
 
-            embed.add_field(name="Preview", value=format_preview(
-                entry["messages"]), inline=False)
+            embed.add_field(name="Preview", value=format_preview(entry["messages"]), inline=False)
 
             if closer is not None:
                 # BUG: Currently, logviewer can't display logs without a closer.
@@ -665,8 +647,7 @@ class Modmail(commands.Cog):
                 logger.debug("Invalid log entry: no closer.")
                 embed.add_field(name="Log Key", value=f"`{entry['key']}`")
 
-            embed.set_footer(text="Recipient ID: " +
-                             str(entry["recipient"]["id"]))
+            embed.set_footer(text="Recipient ID: " + str(entry["recipient"]["id"]))
             embeds.append(embed)
         return embeds
 
@@ -697,8 +678,7 @@ class Modmail(commands.Cog):
         if not user:
             thread = ctx.thread
             if not thread:
-                raise commands.MissingRequiredArgument(
-                    SimpleNamespace(name="member"))
+                raise commands.MissingRequiredArgument(SimpleNamespace(name="member"))
             user = thread.recipient
 
         default_avatar = "https://cdn.discordapp.com/embed/avatars/0.png"
@@ -732,8 +712,7 @@ class Modmail(commands.Cog):
         user = user if user is not None else ctx.author
 
         entries = await self.bot.api.search_closed_by(user.id)
-        embeds = self.format_log_embeds(
-            entries, avatar_url=self.bot.guild.icon_url)
+        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon_url)
 
         if not embeds:
             embed = discord.Embed(
@@ -783,8 +762,7 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.get_responded_logs(user.id)
 
-        embeds = self.format_log_embeds(
-            entries, avatar_url=self.bot.guild.icon_url)
+        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon_url)
 
         if not embeds:
             embed = discord.Embed(
@@ -809,8 +787,7 @@ class Modmail(commands.Cog):
 
         entries = await self.bot.api.search_by_text(query, limit)
 
-        embeds = self.format_log_embeds(
-            entries, avatar_url=self.bot.guild.icon_url)
+        embeds = self.format_log_embeds(entries, avatar_url=self.bot.guild.icon_url)
 
         if not embeds:
             embed = discord.Embed(
@@ -1010,8 +987,7 @@ class Modmail(commands.Cog):
         else:
             thread = await self.bot.threads.create(user, creator=ctx.author, category=category)
             if self.bot.config["dm_disabled"] in (DMDisabled.NEW_THREADS, DMDisabled.ALL_THREADS):
-                logger.info(
-                    "Contacting user %s when Modmail DM is disabled.", user)
+                logger.info("Contacting user %s when Modmail DM is disabled.", user)
 
             if not silent and not self.bot.config.get("thread_contact_silently"):
                 if ctx.author.id == user.id:
@@ -1047,8 +1023,7 @@ class Modmail(commands.Cog):
     async def blocked(self, ctx):
         """Retrieve a list of blocked users."""
 
-        embeds = [discord.Embed(title="Blocked Users",
-                                color=self.bot.main_color, description="")]
+        embeds = [discord.Embed(title="Blocked Users", color=self.bot.main_color, description="")]
 
         roles = []
         users = []
@@ -1087,8 +1062,7 @@ class Modmail(commands.Cog):
             embeds[0].description = "Currently there are no blocked users."
 
         embeds.append(
-            discord.Embed(title="Blocked Roles",
-                          color=self.bot.main_color, description="")
+            discord.Embed(title="Blocked Roles", color=self.bot.main_color, description="")
         )
 
         if roles:
@@ -1193,8 +1167,7 @@ class Modmail(commands.Cog):
             if thread:
                 user_or_role = thread.recipient
             elif after is None:
-                raise commands.MissingRequiredArgument(
-                    SimpleNamespace(name="user"))
+                raise commands.MissingRequiredArgument(SimpleNamespace(name="user"))
             else:
                 raise commands.BadArgument(f'User "{after.arg}" not found.')
 
@@ -1215,8 +1188,7 @@ class Modmail(commands.Cog):
 
         if after is not None:
             if "%" in reason:
-                raise commands.BadArgument(
-                    'The reason contains illegal character "%".')
+                raise commands.BadArgument('The reason contains illegal character "%".')
             if after.arg:
                 reason += f" for `{after.arg}`"
             if after.dt > after.now:
@@ -1272,8 +1244,7 @@ class Modmail(commands.Cog):
             if thread:
                 user_or_role = thread.recipient
             else:
-                raise commands.MissingRequiredArgument(
-                    SimpleNamespace(name="user"))
+                raise commands.MissingRequiredArgument(SimpleNamespace(name="user"))
 
         mention = getattr(user_or_role, "mention", f"`{user_or_role.id}`")
         name = getattr(user_or_role, "name", f"`{user_or_role.id}`")
@@ -1369,8 +1340,7 @@ class Modmail(commands.Cog):
 
         # Search cache for channel
         user_id, thread = next(
-            ((k, v) for k, v in self.bot.threads.cache.items()
-             if v.channel == ctx.channel),
+            ((k, v) for k, v in self.bot.threads.cache.items() if v.channel == ctx.channel),
             (-1, None),
         )
         if thread is not None:

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,7 +1,7 @@
 import base64
+import datetime
 import functools
 import re
-import string
 import typing
 from difflib import get_close_matches
 from distutils.util import strtobool as _stb  # pylint: disable=import-error
@@ -234,7 +234,7 @@ def match_title(text: str) -> int:
     Optional[str]
         The title if found
     """
-    match = TOPIC_TITLE_REGEX.search(text)
+    match = TOPIC_TITLE_REGEX.search(text or "")
     if match is not None:
         return match.group(1)
 
@@ -253,7 +253,7 @@ def match_user_id(text: str) -> int:
     int
         The user ID if found. Otherwise, -1.
     """
-    match = TOPIC_UID_REGEX.search(text)
+    match = TOPIC_UID_REGEX.search(text or "")
     if match is not None:
         return int(match.group(1))
     return -1
@@ -341,10 +341,7 @@ def escape_code_block(text):
 
 def format_channel_name(author, guild, exclude_channel=None):
     """Sanitises a username for use with text channel names"""
-    name = author.name.lower()
-    name = new_name = (
-        "".join(l for l in name if l not in string.punctuation and l.isprintable()) or "null"
-    ) + f"-{author.discriminator}"
+    name = new_name = str(datetime.datetime.now().timestamp())
 
     counter = 1
     existed = set(c.name for c in guild.text_channels if c != exclude_channel)


### PR DESCRIPTION
Anonymize channel names; use a timestamp instead of a username. Remove username from channel topic.

Add ([previously missing?](https://github.com/Microsoft-community/modmail/blob/f883726d5bcf82a59f3ef8e09e3e381ae8e2a9e7/core/thread.py#L1098-L1099)) search of genesis embed to `_find_from_channel()`.

Fix typo