### PR TITLE
Added config option for confirm thread timeout

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -124,6 +124,7 @@ class ConfigManager:
         "confirm_thread_response": "React to confirm thread creation which will directly contact the moderators",
         "confirm_thread_creation_accept": "\N{WHITE HEAVY CHECK MARK}",
         "confirm_thread_creation_deny": "\N{NO ENTRY SIGN}",
+        "confirm_thread_creation_timeout": isodate.Duration(minutes=2),
         # regex
         "use_regex_autotrigger": False,
         "use_hoisted_top_role": True,

--- a/core/thread.py
+++ b/core/thread.py
@@ -1369,7 +1369,7 @@ class ThreadManager:
                     and r.message.id == confirm.id
                     and r.message.channel.id == confirm.channel.id
                     and str(r.emoji) in (accept_emoji, deny_emoji),
-                    timeout=20,
+                    timeout=int(self.bot.config["confirm_thread_creation_timeout"].total_seconds()),
                 )
             except asyncio.TimeoutError:
                 thread.cancelled = True


### PR DESCRIPTION
`confirm_thread_creation_timeout` takes a time (same format as !close for example) and controls how long it takes before a thread auto-cancels because of not confirming